### PR TITLE
NameError on client.unfollow() fixed

### DIFF
--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -209,7 +209,7 @@ class TumblrRestClient(object):
         """
         Follow the url of the given blog
 
-        :param blog_url: a string, the blog url you want to follow
+        :param blogname: a string, the blog url you want to follow
 
         :returns: a dict created from the JSON response
         """
@@ -221,12 +221,12 @@ class TumblrRestClient(object):
         """
         Unfollow the url of the given blog
 
-        :param blog_url: a string, the blog url you want to follow
+        :param blogname: a string, the blog url you want to follow
 
         :returns: a dict created from the JSON response
         """
         url = "/v2/user/unfollow"
-        return self.send_api_request("post", url, {'url': blog_url}, ['url'])
+        return self.send_api_request("post", url, {'url': blogname}, ['url'])
 
     def like(self, id, reblog_key):
         """


### PR DESCRIPTION
Got a NameError on client.unfollow due to an incorrectly named variable.

Resolution:
1. Changed the variable name to match the function parameter
2. Updated docstring of both the .follow() and .unfollow() methods to match the variable name being used.
