### PR TITLE
fixed bug in __init__.py

### DIFF
--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -125,7 +125,7 @@ class TumblrRestClient(object):
             url = '/v2/blog/%s/posts' % blogname
         else:
             url = '/v2/blog/%s/posts/%s' % (blogname,type)
-        return self.send_api_request("get", url, kwargs, ['id', 'tag', 'limit', 'offset', 'reblog_info', 'notes_info', 'filter', 'api_key'], True)
+        return self.send_api_request("get", url, kwargs, ['id', 'tag', 'limit', 'offset', 'reblog_info', 'notes_info', 'filter', 'type', 'api_key'], True)
     
     @validate_blogname
     def blog_info(self, blogname):


### PR DESCRIPTION
Since 'type' was removed as a valid parameter for the posts method, I've restored it.
As I'm looking at the file now, it seems that 'api_key' can also be removed (as it's added in, in send_api_request).
This is not part of my commit, though.
