### PR TITLE
Add photoset_layout as an option to create_photo

### DIFF
--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -498,7 +498,7 @@ class TumblrRestClient(object):
         url = "/v2/blog/%s/post" % blogname
         valid_options = self._post_valid_options(params.get('type', None))
 
-        if 'tags' in params:
+        if len(params.get("tags", [])) > 0:
             # Take a list of tags and make them acceptable for upload
             params['tags'] = ",".join(params['tags'])
 

--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -470,7 +470,7 @@ class TumblrRestClient(object):
         if post_type == 'text':
             valid += ['title', 'body']
         elif post_type == 'photo':
-            valid += ['caption', 'link', 'source', 'data']
+            valid += ['caption', 'link', 'source', 'data', 'photoset_layout']
         elif post_type == 'quote':
             valid += ['quote', 'source']
         elif post_type == 'link':


### PR DESCRIPTION
Even though this is not a documented feature of the Tumblr API, it works well, and this attribute is actually provided by their Posts endpoint (http://www.tumblr.com/docs/en/api/v2#posts)

Allowing this `photoset_layout` option as a valid attribute to create an image post would be a nice addition since it gives full control over how photos are laid out in the template.
