### PR TITLE
Move test dependencies to tests_require.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'httpretty'
     ],
 
-    setup_requires=[
+    tests_require=[
         'nose',
         'nose-cov',
         'mock'


### PR DESCRIPTION
Move nose, nose-cov, and mock to tests_require, since they are only
required for tests and not needed for general package setup.
