### PR TITLE
Fixed 'after' and 'before' params to blog_likes(), Added a test to show problem

### DIFF
--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -168,7 +168,7 @@ class TumblrRestClient(object):
         :returns: A dict created from the JSON response
         """
         url = "/v2/blog/{0}/likes".format(blogname)
-        return self.send_api_request("get", url, kwargs, ['limit', 'offset'], True)
+        return self.send_api_request("get", url, kwargs, ['limit', 'offset', 'before', 'after'], True)
     
     @validate_blogname
     def queue(self, blogname, **kwargs):

--- a/tests/test_pytumblr.py
+++ b/tests/test_pytumblr.py
@@ -75,6 +75,14 @@ class TumblrRestClientTest(unittest.TestCase):
         assert response['liked_posts'] == []
 
     @httprettified
+    def test_blogLikesAfter(self):
+        HTTPretty.register_uri(HTTPretty.GET, 'https://api.tumblr.com/v2/blog/codingjester.tumblr.com/likes',
+                               body='{"meta": {"status": 200, "msg": "OK"}, "response": {"liked_posts": [] } }')
+
+        response = self.client.blog_likes('codingjester.tumblr.com', after=1418458436)
+        assert response['liked_posts'] == []
+
+    @httprettified
     def test_queue(self):
         HTTPretty.register_uri(HTTPretty.GET, 'https://api.tumblr.com/v2/blog/codingjester.tumblr.com/posts/queue',
                                body='{"meta": {"status": 200, "msg": "OK"}, "response": {"posts": [] } }')


### PR DESCRIPTION
Added a test that fails when using the 'after' argument to client.blog_likes(), and added 'after' and 'before' to the valid_parameters list