### PR TITLE
Relative import enables the usage of the library in web2py.

### DIFF
--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -1,5 +1,5 @@
-from helpers import validate_params, validate_blogname
-from request import TumblrRequest
+from .helpers import validate_params, validate_blogname
+from .request import TumblrRequest
 
 
 class TumblrRestClient(object):


### PR DESCRIPTION
The relative import fixes problems when importing the module in web2py and will probably also help with in other projects
