### PR TITLE
Fix Unicode issues (#58)

### DIFF
--- a/pytumblr/helpers.py
+++ b/pytumblr/helpers.py
@@ -1,4 +1,6 @@
 from functools import wraps
+import urllib
+
 
 def validate_params(valid_options, params):
     """
@@ -27,6 +29,18 @@ def validate_params(valid_options, params):
     if disallowed_fields:
         field_strings = ",".join(disallowed_fields)
         raise Exception("{0} are not allowed fields".format(field_strings))
+
+
+def encode_params(params):
+    """
+    Encode params to UTF-8 url parameters.
+    """
+
+    for key in params:
+        if isinstance(params[key], unicode):
+            params[key] = params[key].encode('utf-8')
+    return urllib.urlencode(params)
+
 
 def validate_blogname(fn):
     """

--- a/pytumblr/request.py
+++ b/pytumblr/request.py
@@ -1,4 +1,4 @@
-import urllib
+from pytumblr import helpers
 import urllib2
 import time
 import json
@@ -33,7 +33,7 @@ class TumblrRequest(object):
         """
         url = self.host + url
         if params:
-            url = url + "?" + urllib.urlencode(params)
+            url = url + "?" + helpers.encode_params(params)
 
         client = oauth.Client(self.consumer, self.token)
         try:
@@ -61,7 +61,7 @@ class TumblrRequest(object):
                 return self.post_multipart(url, params, files)
             else:
                 client = oauth.Client(self.consumer, self.token)
-                resp, content = client.request(url, method="POST", body=urllib.urlencode(params), headers=self.headers)
+                resp, content = client.request(url, method="POST", body=helpers.encode_params(params), headers=self.headers)
                 return self.json_parse(content)
         except urllib2.HTTPError, e:
             return self.json_parse(e.read())
@@ -70,16 +70,16 @@ class TumblrRequest(object):
         """
         Wraps and abstracts content validation and JSON parsing
         to make sure the user gets the correct response.
-        
+
         :param content: The content returned from the web request to be parsed as json
-        
+
         :returns: a dict of the json response
         """
         try:
             data = json.loads(content)
         except ValueError, e:
             data = {'meta': { 'status': 500, 'msg': 'Server Error'}, 'response': {"error": "Malformed JSON or HTML was returned."}}
-        
+
         #We only really care about the response if we succeed
         #and the error if we fail
         if data['meta']['status'] in [200, 201, 301]:
@@ -122,7 +122,7 @@ class TumblrRequest(object):
         """
         import mimetools
         import mimetypes
-        BOUNDARY = mimetools.choose_boundary()
+        BOUNDARY = mimetools.choose_boundary().encode('utf-8')
         CRLF = '\r\n'
         L = []
         for (key, value) in fields.items():
@@ -132,7 +132,7 @@ class TumblrRequest(object):
             L.append(value)
         for (key, filename, value) in files:
             L.append('--' + BOUNDARY)
-            L.append('Content-Disposition: form-data; name="{0}"; filename="{1}"'.format(key, filename))
+            L.append('Content-Disposition: form-data; name="{0}"; filename="{1}"'.format(key, filename.encode('utf-8')))
             L.append('Content-Type: {0}'.format(mimetypes.guess_type(filename)[0] or 'application/octet-stream'))
             L.append('Content-Transfer-Encoding: binary')
             L.append('')

--- a/tests/test_pytumblr.py
+++ b/tests/test_pytumblr.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import nose
 import unittest
 import mock
@@ -48,6 +50,14 @@ class TumblrRestClientTest(unittest.TestCase):
 
         args = { 'limit': 1 }
         response = self.client.posts('seejohnrun', 'photo', **args)
+        assert response['posts'] == []
+
+    @httprettified
+    def test_posts_with_unicode_arg(self):
+        HTTPretty.register_uri(HTTPretty.GET, 'https://api.tumblr.com/v2/blog/seejohnrun.tumblr.com/posts?tag=voil%C3%A0',
+                               body='{"meta": {"status": 200, "msg": "OK"}, "response": {"posts": [] } }')
+        args = { 'tag': u'voilà' }
+        response = self.client.posts('seejohnrun', **args)
         assert response['posts'] == []
 
     @httprettified
@@ -143,7 +153,7 @@ class TumblrRestClientTest(unittest.TestCase):
         HTTPretty.register_uri(HTTPretty.POST, 'https://api.tumblr.com/v2/blog/seejohnrun.tumblr.com/post/reblog',
                                body='{"meta": {"status": 200, "msg": "OK"}, "response": []}')
 
-        response = self.client.reblog('seejohnrun', id='123', reblog_key="adsfsadf", state='coolguy', tags=['hello', 'world'])
+        response = self.client.reblog('seejohnrun', id='123', reblog_key="adsfsadf", state='coolguy', tags=['hello', 'world', u'voilà'])
         assert response == []
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
@@ -151,21 +161,21 @@ class TumblrRestClientTest(unittest.TestCase):
         assert experimental_body['id'][0] == '123'
         assert experimental_body['reblog_key'][0] == 'adsfsadf'
         assert experimental_body['state'][0] == 'coolguy'
-        assert experimental_body['tags'][0] == 'hello,world'
+        assert experimental_body['tags'][0] == u'hello,world,voilà'.encode('utf-8')
 
     @httprettified
     def test_edit_post(self):
         HTTPretty.register_uri(HTTPretty.POST, 'https://api.tumblr.com/v2/blog/seejohnrun.tumblr.com/post/edit',
                                body='{"meta": {"status": 200, "msg": "OK"}, "response": []}')
 
-        response = self.client.edit_post('seejohnrun', id='123', state='coolguy', tags=['hello', 'world'])
+        response = self.client.edit_post('seejohnrun', id='123', state='coolguy', tags=['hello', 'world', u'voilà'])
         assert response == []
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
         assert HTTPretty.last_request.method == 'POST'
         assert experimental_body['id'][0] == '123'
         assert experimental_body['state'][0] == 'coolguy'
-        assert experimental_body['tags'][0] == 'hello,world'
+        assert experimental_body['tags'][0] == u'hello,world,voilà'.encode('utf-8')
 
     @httprettified
     def test_like(self):
@@ -242,11 +252,19 @@ class TumblrRestClientTest(unittest.TestCase):
         assert response == []
 
     @httprettified
+    def test_tagged_unicode(self):
+        HTTPretty.register_uri(HTTPretty.GET, 'https://api.tumblr.com/v2/tagged?tag=voil%C3%A0',
+                               body='{"meta": {"status": 200, "msg": "OK"}, "response": []}')
+
+        response = self.client.tagged(u'voilà')
+        assert response == []
+
+    @httprettified
     def test_create_text(self):
         HTTPretty.register_uri(HTTPretty.POST, 'https://api.tumblr.com/v2/blog/codingjester.tumblr.com/post',
                                body='{"meta": {"status": 201, "msg": "OK"}, "response": []}')
 
-        response = self.client.create_text('codingjester.tumblr.com', body="Testing")
+        response = self.client.create_text('codingjester.tumblr.com', body=u"Testing äöü")
         assert response == []
 
     @httprettified
@@ -254,12 +272,12 @@ class TumblrRestClientTest(unittest.TestCase):
         HTTPretty.register_uri(HTTPretty.POST, 'https://api.tumblr.com/v2/blog/codingjester.tumblr.com/post',
                                body='{"meta": {"status": 201, "msg": "OK"}, "response": []}')
 
-        response = self.client.create_link('codingjester.tumblr.com', url="https://google.com", tags=['omg', 'nice'])
+        response = self.client.create_link('codingjester.tumblr.com', url="https://google.com", tags=['omg', 'nice', u'voilà'])
         assert response == []
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
         assert HTTPretty.last_request.method == "POST"
-        assert experimental_body['tags'][0] == "omg,nice"
+        assert experimental_body['tags'][0] == u"omg,nice,voilà".encode('utf-8')
 
     @httprettified
     def test_no_tags(self):
@@ -275,7 +293,7 @@ class TumblrRestClientTest(unittest.TestCase):
         HTTPretty.register_uri(HTTPretty.POST, 'https://api.tumblr.com/v2/blog/codingjester.tumblr.com/post',
                                body='{"meta": {"status": 201, "msg": "OK"}, "response": []}')
 
-        response = self.client.create_quote('codingjester.tumblr.com', quote="It's better to love and lost, than never have loved at all.")
+        response = self.client.create_quote('codingjester.tumblr.com', quote=u"It's better to love and lost, than never have loved at all. ♥")
         assert response == []
 
     @httprettified
@@ -283,28 +301,42 @@ class TumblrRestClientTest(unittest.TestCase):
         HTTPretty.register_uri(HTTPretty.POST, 'https://api.tumblr.com/v2/blog/codingjester.tumblr.com/post',
                                body='{"meta": {"status": 201, "msg": "OK"}, "response": []}')
 
-        response = self.client.create_chat('codingjester.tumblr.com', conversation="JB: Testing is rad.\nJC: Hell yeah.")
+        response = self.client.create_chat('codingjester.tumblr.com', conversation=u"JB: Testing is rad.\nJC: Hell yeah. ♥")
         assert response == []
 
     @httprettified
-    def test_create_photo(self):
+    def test_create_photo_from_url(self):
         HTTPretty.register_uri(HTTPretty.POST, 'https://api.tumblr.com/v2/blog/codingjester.tumblr.com/post',
                                body='{"meta": {"status": 201, "msg": "OK"}, "response": []}')
 
         response = self.client.create_photo('codingjester.tumblr.com', source="https://media.tumblr.com/image.jpg")
         assert response == []
 
-        #with mock.patch('__builtin__.open') as my_mock:
-        #    my_mock.return_value.__enter__ = lambda s: s
-        #    my_mock.return_value.__exit__ = mock.Mock()
-        #    my_mock.return_value.read.return_value = 'some data'
-        #    response = self.client.create_photo('codingjester.tumblr.com', data="/Users/johnb/Desktop/gozer_avatar.jpgdf")
-        #    assert response['meta']['status'] == 201
-        #    assert response['meta']['msg'] == "OK"
 
-        #response = self.client.create_photo('codingjester.tumblr.com', data=["/Users/johnb/Desktop/gozer_avatar.jpg", "/Users/johnb/Desktop/gozer_avatar.jpg"])
-        #assert response['meta']['status'] == 201
-        #assert response['meta']['msg'] == "OK"
+    # For some reason, mocking open causes mimetypes.guess_type to
+    # hang. Mocking guess_type isn't ideal since we're overriding part
+    # of what we're testing. Find better solution?
+    @httprettified
+    @mock.patch('mimetypes.guess_type')
+    def test_create_photo_from_file(self, mockguess):
+        HTTPretty.register_uri(HTTPretty.POST, 'https://api.tumblr.com/v2/blog/codingjester.tumblr.com/post',
+                               body='{"meta": {"status": 201, "msg": "OK"}, "response": []}')
+        mockopen = mock.mock_open(read_data='some data')
+        mockguess.return_value = 'jpg'
+        with mock.patch('__builtin__.open', mockopen, create=True):
+            response = self.client.create_photo('codingjester.tumblr.com', data="/Users/johnb/Desktop/gozer_avatar.jpg")
+        assert response == []
+
+    @httprettified
+    @mock.patch('mimetypes.guess_type')
+    def test_create_photo_from_file_with_unicode(self, mockguess):
+        HTTPretty.register_uri(HTTPretty.POST, 'https://api.tumblr.com/v2/blog/codingjester.tumblr.com/post',
+                               body='{"meta": {"status": 201, "msg": "OK"}, "response": []}')
+        mockopen = mock.mock_open(read_data='some data')
+        mockguess.return_value = 'jpg'
+        with mock.patch('__builtin__.open'.format(__name__), mockopen, create=True):
+           response = self.client.create_photo('codingjester.tumblr.com', data=u"/Users/johnb/Desktop/gözer_avatar.jpg")
+        assert response == []
 
     @httprettified
     def test_create_audio(self):


### PR DESCRIPTION
This should fix the issues mentioned in #58. I've manually tested the upload of an image file which contains umlauts in the filename, and getting posts by a tag containing umlauts.

Unfortunately, I had problems mocking the open function in the UnitTests. That part was commented, so I guess I wasn't the only one. ;) With open mocked, mimetypes.guess_types hangs infinitely. I could work around that by mocking guess_types as well, though that means mocking away part of what we want to test. It's better than nothing, though.
