### PR TITLE
Python 2/3 support for PyTumblr.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "2.6"
   - "2.7"
   - "pypy"
+  - "3.3"
 script:
   - python setup.py test

--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -1,5 +1,8 @@
-from helpers import validate_params, validate_blogname
-from request import TumblrRequest
+from __future__ import absolute_import
+from builtins import str
+from builtins import object
+from .helpers import validate_params, validate_blogname
+from .request import TumblrRequest
 
 
 class TumblrRestClient(object):
@@ -39,9 +42,9 @@ class TumblrRestClient(object):
     def avatar(self, blogname, size=64):
         """
         Retrieves the url of the blog's avatar
-        
+
         :param blogname: a string, the blog you want the avatar for
-        
+
         :returns: A dict created from the JSON response
         """
         url = "/v2/blog/{0}/avatar/{1}".format(blogname, size)
@@ -106,7 +109,7 @@ class TumblrRestClient(object):
         """
         kwargs.update({'tag': tag})
         return self.send_api_request("get", '/v2/tagged', kwargs, ['before', 'limit', 'filter', 'tag', 'api_key'], True)
-    
+
     @validate_blogname
     def posts(self, blogname, type=None, **kwargs):
         """
@@ -126,9 +129,9 @@ class TumblrRestClient(object):
         if type is None:
             url = '/v2/blog/{0}/posts'.format(blogname)
         else:
-            url = '/v2/blog/{0}/posts/{1}'.format(blogname,type)
+            url = '/v2/blog/{0}/posts/{1}'.format(blogname, type)
         return self.send_api_request("get", url, kwargs, ['id', 'tag', 'limit', 'offset', 'reblog_info', 'notes_info', 'filter', 'api_key'], True)
-    
+
     @validate_blogname
     def blog_info(self, blogname):
         """
@@ -141,7 +144,7 @@ class TumblrRestClient(object):
         """
         url = "/v2/blog/{0}/info".format(blogname)
         return self.send_api_request("get", url, {}, ['api_key'], True)
-    
+
     @validate_blogname
     def followers(self, blogname, **kwargs):
         """
@@ -156,7 +159,7 @@ class TumblrRestClient(object):
         """
         url = "/v2/blog/{0}/followers".format(blogname)
         return self.send_api_request("get", url, kwargs, ['limit', 'offset'])
-    
+
     @validate_blogname
     def blog_likes(self, blogname, **kwargs):
         """
@@ -173,7 +176,7 @@ class TumblrRestClient(object):
         """
         url = "/v2/blog/{0}/likes".format(blogname)
         return self.send_api_request("get", url, kwargs, ['limit', 'offset', 'before', 'after'], True)
-    
+
     @validate_blogname
     def queue(self, blogname, **kwargs):
         """
@@ -283,7 +286,7 @@ class TumblrRestClient(object):
         """
         kwargs.update({"type": "photo"})
         return self._send_post(blogname, kwargs)
-    
+
     @validate_blogname
     def create_text(self, blogname, **kwargs):
         """
@@ -521,18 +524,16 @@ class TumblrRestClient(object):
         :returns: a dict parsed from the JSON response
         """
         if needs_api_key:
-            params.update({'api_key': self.request.consumer.key})
+            params.update({'api_key': self.request.consumer_key})
             valid_parameters.append('api_key')
 
-        files = []
+        files = {}
         if 'data' in params:
             if isinstance(params['data'], list):
                 for idx, data in enumerate(params['data']):
-                    with open(data, 'rb') as f:
-                        files.append(('data['+str(idx)+']', data, f.read()))
+                    files['data['+str(idx)+']'] =  open(params['data'][idx], 'rb')
             else:
-                with open(params['data'], 'rb') as f:
-                    files = [('data', params['data'], f.read())]
+                files = {'data': open(params['data'], 'rb')}
             del params['data']
 
         validate_params(valid_parameters, params)

--- a/pytumblr/request.py
+++ b/pytumblr/request.py
@@ -1,25 +1,32 @@
-import urllib
-import urllib2
-import time
-import json
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
+import urllib.parse
+import requests
 
-from urlparse import parse_qsl
-import oauth2 as oauth
-from httplib2 import RedirectLimit
+from requests_oauthlib import OAuth1
+from requests.exceptions import TooManyRedirects, HTTPError
+
 
 class TumblrRequest(object):
     """
     A simple request object that lets us query the Tumblr API
     """
 
-    __version = "0.0.7";
+    __version = "0.0.7"
 
     def __init__(self, consumer_key, consumer_secret="", oauth_token="", oauth_secret="", host="https://api.tumblr.com"):
         self.host = host
-        self.consumer = oauth.Consumer(key=consumer_key, secret=consumer_secret)
-        self.token = oauth.Token(key=oauth_token, secret=oauth_secret)
+        self.oauth = OAuth1(
+            consumer_key,
+            client_secret=consumer_secret,
+            resource_owner_key=oauth_token,
+            resource_owner_secret=oauth_secret
+        )
+        self.consumer_key = consumer_key
+
         self.headers = {
-            "User-Agent" : "pytumblr/" + self.__version
+            "User-Agent": "pytumblr/" + self.__version,
         }
 
     def get(self, url, params):
@@ -33,16 +40,14 @@ class TumblrRequest(object):
         """
         url = self.host + url
         if params:
-            url = url + "?" + urllib.urlencode(params)
+            url = url + "?" + urllib.parse.urlencode(params)
 
-        client = oauth.Client(self.consumer, self.token)
         try:
-            client.follow_redirects = False
-            resp, content = client.request(url, method="GET", redirections=False, headers=self.headers)
-        except RedirectLimit, e:
-            resp, content = e.args
+            resp = requests.get(url, allow_redirects=False, headers=self.headers, auth=self.oauth)
+        except TooManyRedirects as e:
+            resp = e.response
 
-        return self.json_parse(content)
+        return self.json_parse(resp)
 
     def post(self, url, params={}, files=[]):
         """
@@ -60,28 +65,27 @@ class TumblrRequest(object):
             if files:
                 return self.post_multipart(url, params, files)
             else:
-                client = oauth.Client(self.consumer, self.token)
-                resp, content = client.request(url, method="POST", body=urllib.urlencode(params), headers=self.headers)
-                return self.json_parse(content)
-        except urllib2.HTTPError, e:
-            return self.json_parse(e.read())
+                resp = requests.post(url, data=urllib.parse.urlencode(params), headers=self.headers, auth=self.oauth)
+                return self.json_parse(resp)
+        except HTTPError as e:
+            return self.json_parse(e.response)
 
-    def json_parse(self, content):
+    def json_parse(self, response):
         """
-        Wraps and abstracts content validation and JSON parsing
+        Wraps and abstracts response validation and JSON parsing
         to make sure the user gets the correct response.
-        
-        :param content: The content returned from the web request to be parsed as json
-        
+
+        :param response: The response returned to us from the request
+
         :returns: a dict of the json response
         """
         try:
-            data = json.loads(content)
-        except ValueError, e:
+            data = response.json()
+        except ValueError:
             data = {'meta': { 'status': 500, 'msg': 'Server Error'}, 'response': {"error": "Malformed JSON or HTML was returned."}}
-        
-        #We only really care about the response if we succeed
-        #and the error if we fail
+
+        # We only really care about the response if we succeed
+        # and the error if we fail
         if data['meta']['status'] in [200, 201, 301]:
             return data['response']
         else:
@@ -93,68 +97,17 @@ class TumblrRequest(object):
 
         :param url: a string, the url you are requesting
         :param params: a dict, a key-value of all the parameters
-        :param files:  a list, the list of tuples for your data
+        :param files:  a dict, matching the form '{name: file descriptor}'
 
         :returns: a dict parsed from the JSON response
         """
-        #combine the parameters with the generated oauth params
-        params = dict(params.items() + self.generate_oauth_params().items())
-        faux_req = oauth.Request(method="POST", url=url, parameters=params)
-        faux_req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), self.consumer, self.token)
-        params = dict(parse_qsl(faux_req.to_postdata()))
-
-        content_type, body = self.encode_multipart_formdata(params, files)
-        headers = {'Content-Type': content_type, 'Content-Length': str(len(body))}
-
-        #Do a bytearray of the body and everything seems ok
-        r = urllib2.Request(url, bytearray(body), headers)
-        content = urllib2.urlopen(r).read()
-        return self.json_parse(content)
-
-    def encode_multipart_formdata(self, fields, files):
-        """
-        Properly encodes the multipart body of the request
-
-        :param fields: a dict, the parameters used in the request
-        :param files:  a list of tuples containing information about the files
-
-        :returns: the content for the body and the content-type value
-        """
-        import mimetools
-        import mimetypes
-        BOUNDARY = mimetools.choose_boundary()
-        CRLF = '\r\n'
-        L = []
-        for (key, value) in fields.items():
-            L.append('--' + BOUNDARY)
-            L.append('Content-Disposition: form-data; name="{0}"'.format(key))
-            L.append('')
-            L.append(value)
-        for (key, filename, value) in files:
-            L.append('--' + BOUNDARY)
-            L.append('Content-Disposition: form-data; name="{0}"; filename="{1}"'.format(key, filename))
-            L.append('Content-Type: {0}'.format(mimetypes.guess_type(filename)[0] or 'application/octet-stream'))
-            L.append('Content-Transfer-Encoding: binary')
-            L.append('')
-            L.append(value)
-        L.append('--' + BOUNDARY + '--')
-        L.append('')
-        body = CRLF.join(L)
-        content_type = 'multipart/form-data; boundary={0}'.format(BOUNDARY)
-        return content_type, body
-
-    def generate_oauth_params(self):
-        """
-        Generates the oauth parameters needed for multipart/form requests
-
-        :returns: a dictionary of the proper headers that can be used
-                  in the request
-        """
-        params = {
-            'oauth_version': "1.0",
-            'oauth_nonce': oauth.generate_nonce(),
-            'oauth_timestamp': int(time.time()),
-            'oauth_token': self.token.key,
-            'oauth_consumer_key': self.consumer.key
-        }
-        return params
+        resp = requests.post(
+            url,
+            data=params,
+            params=params,
+            files=files,
+            headers=self.headers,
+            allow_redirects=False,
+            auth=self.oauth
+        )
+        return self.json_parse(resp)

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ setup(
     test_suite='nose.collector',
 
     install_requires = [
-        'oauth2',
-        'httpretty'
+        'future',
+        'requests-oauthlib',
+        'httpretty',
     ],
 
     tests_require=[

--- a/tests/test_pytumblr.py
+++ b/tests/test_pytumblr.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 import nose
 import unittest
 import mock
@@ -5,7 +8,7 @@ import json
 import io
 from httpretty import HTTPretty, httprettified
 import pytumblr
-from urlparse import parse_qs
+from urllib.parse import parse_qs
 
 
 class TumblrRestClientTest(unittest.TestCase):
@@ -124,7 +127,7 @@ class TumblrRestClientTest(unittest.TestCase):
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
         assert HTTPretty.last_request.method == "POST"
-        assert experimental_body['url'][0] == 'codingjester.tumblr.com'
+        assert experimental_body[b'url'][0] == b'codingjester.tumblr.com'
 
     @httprettified
     def test_unfollow(self):
@@ -136,7 +139,7 @@ class TumblrRestClientTest(unittest.TestCase):
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
         assert HTTPretty.last_request.method == "POST"
-        assert experimental_body['url'][0] == 'codingjester.tumblr.com'
+        assert experimental_body[b'url'][0] == b'codingjester.tumblr.com'
 
     @httprettified
     def test_reblog(self):
@@ -148,10 +151,10 @@ class TumblrRestClientTest(unittest.TestCase):
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
         assert HTTPretty.last_request.method == 'POST'
-        assert experimental_body['id'][0] == '123'
-        assert experimental_body['reblog_key'][0] == 'adsfsadf'
-        assert experimental_body['state'][0] == 'coolguy'
-        assert experimental_body['tags'][0] == 'hello,world'
+        assert experimental_body[b'id'][0] == b'123'
+        assert experimental_body[b'reblog_key'][0] == b'adsfsadf'
+        assert experimental_body[b'state'][0] == b'coolguy'
+        assert experimental_body[b'tags'][0] == b'hello,world'
 
     @httprettified
     def test_edit_post(self):
@@ -163,9 +166,9 @@ class TumblrRestClientTest(unittest.TestCase):
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
         assert HTTPretty.last_request.method == 'POST'
-        assert experimental_body['id'][0] == '123'
-        assert experimental_body['state'][0] == 'coolguy'
-        assert experimental_body['tags'][0] == 'hello,world'
+        assert experimental_body[b'id'][0] == b'123'
+        assert experimental_body[b'state'][0] == b'coolguy'
+        assert experimental_body[b'tags'][0] == b'hello,world'
 
     @httprettified
     def test_like(self):
@@ -177,8 +180,8 @@ class TumblrRestClientTest(unittest.TestCase):
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
         assert HTTPretty.last_request.method == "POST"
-        assert experimental_body['id'][0] == '123'
-        assert experimental_body['reblog_key'][0] == 'adsfsadf'
+        assert experimental_body[b'id'][0] == b'123'
+        assert experimental_body[b'reblog_key'][0] == b'adsfsadf'
 
     @httprettified
     def test_unlike(self):
@@ -190,8 +193,8 @@ class TumblrRestClientTest(unittest.TestCase):
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
         assert HTTPretty.last_request.method == "POST"
-        assert experimental_body['id'][0] == '123'
-        assert experimental_body['reblog_key'][0] == 'adsfsadf'
+        assert experimental_body[b'id'][0] == b'123'
+        assert experimental_body[b'reblog_key'][0] == b'adsfsadf'
 
     @httprettified
     def test_info(self):
@@ -259,7 +262,7 @@ class TumblrRestClientTest(unittest.TestCase):
 
         experimental_body = parse_qs(HTTPretty.last_request.body)
         assert HTTPretty.last_request.method == "POST"
-        assert experimental_body['tags'][0] == "omg,nice"
+        assert experimental_body[b'tags'][0] == b"omg,nice"
 
     @httprettified
     def test_no_tags(self):


### PR DESCRIPTION
I have updated the PyTumblr code to be both backwards compatible with Python 2 and forwards compatible with Python 3.

Some notes about what I've done:
- Since the oauth2 library isn't Python 3 compatible, I've ripped it out and replaced it with requests-oauthlib, which has cleaned up the multipart posting quite a bit. 
- I've used the [`future`](http://python-future.org/) library to be the compatibility layer for both Python 2 and Python 3, hence I've added it as a requirement.
- I have done some manual testing in both Python 2 and 3 to ensure that the major functionality is still working the way we'd expect, including file uploads.
- It seems like HTTPretty is giving us back values as Python bytestrings, so I had to update the tests to reflect that. If this is a concern, let me know.
- There's some issues with running the tests under 3.4 due to how HTTPretty does its mocking of sockets (see [this issue](https://github.com/gabrielfalcao/HTTPretty/issues/221) for more details), so I've only added 3.3 to be run on Travis. The client itself runs fine under Python 3.4.
- There's also a few minor PEP8 fixes that I've tossed in as well.

I'm reading over the CLA right now. I'll try to get it sent in on Tuesday if you're are interested in ever trying to merge this. I'm happy to make updates based on any code review feedback you may have.
