### PR TITLE
Fix error with future.types.newstr.newstr and urllib.quote KeyError

### DIFF
--- a/pytumblr/request.py
+++ b/pytumblr/request.py
@@ -3,6 +3,9 @@ standard_library.install_aliases()
 from builtins import object
 import urllib.parse
 import requests
+import sys
+
+PY3 = sys.version_info[0] == 3
 
 from requests_oauthlib import OAuth1
 from requests.exceptions import TooManyRedirects, HTTPError
@@ -65,7 +68,10 @@ class TumblrRequest(object):
             if files:
                 return self.post_multipart(url, params, files)
             else:
-                resp = requests.post(url, data=urllib.parse.urlencode(params), headers=self.headers, auth=self.oauth)
+                data = urllib.parse.urlencode(params)
+                if not PY3:
+                    data = bytes(data)
+                resp = requests.post(url, data=data, headers=self.headers, auth=self.oauth)
                 return self.json_parse(resp)
         except HTTPError as e:
             return self.json_parse(e.response)

--- a/pytumblr/request.py
+++ b/pytumblr/request.py
@@ -70,7 +70,7 @@ class TumblrRequest(object):
             else:
                 data = urllib.parse.urlencode(params)
                 if not PY3:
-                    data = bytes(data)
+                    data = str(data)
                 resp = requests.post(url, data=data, headers=self.headers, auth=self.oauth)
                 return self.json_parse(resp)
         except HTTPError as e:


### PR DESCRIPTION
Merging in the code that uses `future` and `requests-oauthlib` created a problem with python2, creating a text post with spaces in the body is now raising an exception:

```python
txt = client.create_text(
    blogName,
    state="published",
    slug="testing-text-posts",
    title="Testing",
    body="testing1 2 3 4")
```
raised `KeyError: 116` in urllib.quote

This change converts the `future.types.newstr.newstr` to `bytes` and fixes the problem