### PR TITLE
Handle 302 responses same as other successes; fix avatars

### DIFF
--- a/pytumblr/request.py
+++ b/pytumblr/request.py
@@ -92,7 +92,7 @@ class TumblrRequest(object):
 
         # We only really care about the response if we succeed
         # and the error if we fail
-        if data['meta']['status'] in [200, 201, 301]:
+        if 200 <= data['meta']['status'] <= 399:
             return data['response']
         else:
             return data

--- a/tests/test_pytumblr.py
+++ b/tests/test_pytumblr.py
@@ -78,6 +78,20 @@ class TumblrRestClientTest(unittest.TestCase):
         assert response['blog'] == {}
 
     @mock.patch('requests.get')
+    def test_avatar_with_301(self, mock_get):
+        mock_get.side_effect = wrap_response('{"meta": {"status": 301, "msg": "Moved Permanently"}, "response": {"avatar_url": "" } }')
+
+        response = self.client.avatar('staff.tumblr.com')
+        assert response['avatar_url'] == ''
+
+    @mock.patch('requests.get')
+    def test_avatar_with_302(self, mock_get):
+        mock_get.side_effect = wrap_response('{"meta": {"status": 302, "msg": "Found"}, "response": {"avatar_url": "" } }')
+
+        response = self.client.avatar('staff.tumblr.com')
+        assert response['avatar_url'] == ''
+
+    @mock.patch('requests.get')
     def test_followers(self, mock_get):
         mock_get.side_effect = wrap_response('{"meta": {"status": 200, "msg": "OK"}, "response": {"users": [] } }')
 


### PR DESCRIPTION
### Description

We previously only treated 200, 201 and 301 http response codes as successes, and everything else as an error. Switch to treating all codes between 200 and 399 as successes.

This was necessary due to a backend change where avatars are now returned as 302 responses instead of 301, causing their entire json payload to be returned instead of just the relevant portion.

### Testing

Unit tests added to show the expected return from the `client.avatar()` call. You can also observe via the following:

```
master
>>> client.avatar('staff')
{u'meta': {u'status': 302, u'msg': u'Found'}, u'response': {u'avatar_url': u'https://78.media.tumblr.com/avatar_4490c797e72f_64.png'}}

branch
>>> client.avatar('staff')
{u'avatar_url': u'https://78.media.tumblr.com/avatar_4490c797e72f_64.png'}
``` 