### PR TITLE
Installation added to readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ Two easy ways to get your credentials to are:
 
 1. The built-in ``interactive_console.py`` tool (if you already have a consumer key & secret)
 2. The Tumblr API console at https://api.tumblr.com/console
+3. Get sample login code at https://api.tumblr.com/console/calls/user/info
 
 Supported Methods
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,26 @@
 PyTumblr
 ========
-
 |Build Status|
+
+Installation
+============
+
+Install via pip:
+
+.. code-block:: bash
+
+    $ pip install pytumblr
+
+Install from source:
+
+.. code-block:: bash
+
+    $ git clone https://github.com/tumblr/pytumblr.git
+    $ cd 3taps
+    $ python setup.py install
+
+Usage
+=====
 
 Create a client
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Install from source:
 .. code-block:: bash
 
     $ git clone https://github.com/tumblr/pytumblr.git
-    $ cd 3taps
+    $ cd pytumblr
     $ python setup.py install
 
 Usage


### PR DESCRIPTION
As an API v2 user, I encountered with this problem, I needed to install it but since there wasn't clear information about if it is available in pip I tried and saw that it is available, but with adding these tutorial lines it would be easier for the new users. It also includes the downloading and installing it via `setup.py` version of the installation.

Need to be added:

- [ ] Features
- [ ] Dependencies