### PR TITLE
input fields fixed

### DIFF
--- a/interactive_console.py
+++ b/interactive_console.py
@@ -18,8 +18,8 @@ def new_oauth(yaml_path):
     '''
 
     print('Retrieve consumer key and consumer secret from http://www.tumblr.com/oauth/apps')
-    consumer_key = input('Paste the consumer key here: ')
-    consumer_secret = input('Paste the consumer secret here: ')
+    consumer_key = input('Paste the consumer key here: ').strip()
+    consumer_secret = input('Paste the consumer secret here: ').strip()
 
     request_token_url = 'http://www.tumblr.com/oauth/request_token'
     authorize_url = 'http://www.tumblr.com/oauth/authorize'
@@ -36,7 +36,7 @@ def new_oauth(yaml_path):
 
     # Redirect to authentication page
     print('\nPlease go here and authorize:\n{}'.format(full_authorize_url))
-    redirect_response = input('Allow then paste the full redirect URL here:\n')
+    redirect_response = input('Allow then paste the full redirect URL here:\n').strip()
 
     # Retrieve oauth verifier
     oauth_response = oauth_session.parse_authorization_response(redirect_response)


### PR DESCRIPTION
Input fields may have extra blank spaces which can cause the termination of the program due to wrong tokens/secret keys. Especially in the web browser in this link (https://www.tumblr.com/oauth/apps), when you double click on the secret key to select all of the key and copy, it selects extra three or more blank spaces which cause failure and termination of the program.