### PR TITLE
Add support for HTTP DELETE in API requests

### DIFF
--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -559,5 +559,7 @@ class TumblrRestClient(object):
         validate_params(valid_parameters, params)
         if method == "get":
             return self.request.get(url, params)
+        elif method == "delete":
+            return self.request.delete(url, params)
         else:
             return self.request.post(url, params, files)

--- a/pytumblr/request.py
+++ b/pytumblr/request.py
@@ -76,6 +76,26 @@ class TumblrRequest(object):
         except HTTPError as e:
             return self.json_parse(e.response)
 
+    def delete(self, url, params):
+        """
+        Issues a DELETE request against the API, properly formatting the params
+
+        :param url: a string, the url you are requesting
+        :param params: a dict, the key-value of all the paramaters needed
+                       in the request
+        :returns: a dict parsed of the JSON response
+        """
+        url = self.host + url
+        if params:
+            url = url + "?" + urllib.parse.urlencode(params)
+
+        try:
+            resp = requests.delete(url, allow_redirects=False, headers=self.headers, auth=self.oauth)
+        except TooManyRedirects as e:
+            resp = e.response
+
+        return self.json_parse(resp)
+
     def json_parse(self, response):
         """
         Wraps and abstracts response validation and JSON parsing

--- a/tests/test_pytumblr.py
+++ b/tests/test_pytumblr.py
@@ -313,6 +313,14 @@ class TumblrRestClientTest(unittest.TestCase):
         response = self.client.create_video('codingjester.tumblr.com', embed="blahblahembed")
         assert response == []
 
+    @mock.patch('requests.delete')
+    def test_api_delete(self, mock_delete):
+        mock_delete.side_effect = wrap_response('{"meta": {"status": 200, "msg": "OK"}, "response": []}')
+
+        api_url = '/v2/some/api'
+        response = self.client.send_api_request('delete', api_url, {'param1': 'foo', 'param2': 'bar'}, ['param1', 'param2'], False)
+        assert response == []
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We can use `client.send_api_request` to make GET and POST requests to any endpoint directly, but some endpoints might require DELETE. This PR just adds basic support for DELETE requests.