### PR TITLE
Recognize `npf` as valid param for /posts/* endpoints

### DIFF
--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -131,7 +131,7 @@ class TumblrRestClient(object):
             url = '/v2/blog/{}/posts'.format(blogname)
         else:
             url = '/v2/blog/{}/posts/{}'.format(blogname, type)
-        return self.send_api_request("get", url, kwargs, ['id', 'tag', 'limit', 'offset', 'before', 'reblog_info', 'notes_info', 'filter', 'api_key'], True)
+        return self.send_api_request("get", url, kwargs, ['id', 'tag', 'limit', 'offset', 'before', 'reblog_info', 'notes_info', 'filter', 'api_key', 'npf'], True)
 
     @validate_blogname
     def blog_info(self, blogname):
@@ -209,7 +209,7 @@ class TumblrRestClient(object):
         :returns: a dict created from the JSON response
         """
         url = "/v2/blog/{}/posts/queue".format(blogname)
-        return self.send_api_request("get", url, kwargs, ['limit', 'offset', 'filter'])
+        return self.send_api_request("get", url, kwargs, ['limit', 'offset', 'filter', 'npf'])
 
     @validate_blogname
     def drafts(self, blogname, **kwargs):
@@ -220,12 +220,12 @@ class TumblrRestClient(object):
         :returns: a dict created from the JSON response
         """
         url = "/v2/blog/{}/posts/draft".format(blogname)
-        return self.send_api_request("get", url, kwargs, ['filter'])
+        return self.send_api_request("get", url, kwargs, ['filter', 'npf'])
 
     @validate_blogname
     def submission(self, blogname, **kwargs):
         """
-        Gets posts that are currently in the blog's queue
+        Gets posts that are currently in the blog's submission list
 
         :param offset: an int, the post you want to start at, for pagination.
         :param filter: the post format that you want returned: HTML, text, raw.
@@ -233,7 +233,7 @@ class TumblrRestClient(object):
         :returns: a dict created from the JSON response
         """
         url = "/v2/blog/{}/posts/submission".format(blogname)
-        return self.send_api_request("get", url, kwargs, ["offset", "filter"])
+        return self.send_api_request("get", url, kwargs, ['offset', 'filter', 'npf'])
 
     @validate_blogname
     def follow(self, blogname):


### PR DESCRIPTION
This PR modifies `TumblrRestClient` methods that retrieve posts, so that they accept `npf` as a valid parameter name.

This allows the user to retrieve posts in NPF, which is currently impossible using public methods of `TumblrRestClient`.

Thus, it will allow users of pytumblr to obey the following [recommendation](https://github.com/tumblr/docs/commit/e609ff77e98bd27cc26ad4301745489cc0aba4a3#diff-923f2a1adb38cee10b42249687afeb99381f08c15498248b26a61bf94ee23bf6R586) in the API docs:

> Eventually, all posts will be NPF, so we strongly encourage leveraging NPF JSON via `npf=true` for post content when consuming posts via the API.


(For context, see discussion at tumblr/docs#36.)

