### PR TITLE
Add support for source_url in posts

### DIFF
--- a/pytumblr/__init__.py
+++ b/pytumblr/__init__.py
@@ -297,6 +297,7 @@ class TumblrRestClient(object):
         :param date: a string, the GMT date and time of the post
         :param format: a string, sets the format type of the post. html or markdown
         :param slug: a string, a short text summary to the end of the post url
+        :param source_url: a string, a source attribution for the post content
         :param caption: a string, the caption that you want applied to the photo
         :param link: a string, the 'click-through' url you want on the photo
         :param source: a string, the photo source url
@@ -319,6 +320,7 @@ class TumblrRestClient(object):
         :param date: a string, the GMT date and time of the post
         :param format: a string, sets the format type of the post. html or markdown
         :param slug: a string, a short text summary to the end of the post url
+        :param source_url: a string, a source attribution for the post content
         :param title: a string, the optional title of a post
         :param body: a string, the body of the text post
 
@@ -339,6 +341,7 @@ class TumblrRestClient(object):
         :param date: a string, the GMT date and time of the post
         :param format: a string, sets the format type of the post. html or markdown
         :param slug: a string, a short text summary to the end of the post url
+        :param source_url: a string, a source attribution for the post content
         :param quote: a string, the full text of the quote
         :param source: a string, the cited source of the quote
 
@@ -359,6 +362,7 @@ class TumblrRestClient(object):
         :param date: a string, the GMT date and time of the post
         :param format: a string, sets the format type of the post. html or markdown
         :param slug: a string, a short text summary to the end of the post url
+        :param source_url: a string, a source attribution for the post content
         :param title: a string, the title of the link
         :param url: a string, the url of the link you are posting
         :param description: a string, the description of the link you are posting
@@ -380,6 +384,7 @@ class TumblrRestClient(object):
         :param date: a string, the GMT date and time of the post
         :param format: a string, sets the format type of the post. html or markdown
         :param slug: a string, a short text summary to the end of the post url
+        :param source_url: a string, a source attribution for the post content
         :param title: a string, the title of the conversation
         :param conversation: a string, the conversation you are posting
 
@@ -400,6 +405,7 @@ class TumblrRestClient(object):
         :param date: a string, the GMT date and time of the post
         :param format: a string, sets the format type of the post. html or markdown
         :param slug: a string, a short text summary to the end of the post url
+        :param source_url: a string, a source attribution for the post content
         :param caption: a string, the caption for the post
         :param external_url: a string, the url of the audio you are uploading
         :param data: a string, the local filename path of the audio you are uploading
@@ -421,6 +427,7 @@ class TumblrRestClient(object):
         :param date: a string, the GMT date and time of the post
         :param format: a string, sets the format type of the post. html or markdown
         :param slug: a string, a short text summary to the end of the post url
+        :param source_url: a string, a source attribution for the post content
         :param caption: a string, the caption for the post
         :param embed: a string, the emebed code that you'd like to upload
         :param data: a string, the local filename path of the video you are uploading
@@ -475,6 +482,7 @@ class TumblrRestClient(object):
         :param date: a string, the GMT date and time of the post
         :param format: a string, sets the format type of the post. html or markdown
         :param slug: a string, a short text summary to the end of the post url
+        :param source_url: a string, a source attribution for the post content
         :param id: an int, the post id that you want to edit
 
         :returns: a dict created from the JSON response
@@ -508,7 +516,7 @@ class TumblrRestClient(object):
     # Parameters valid for /post, /post/edit, and /post/reblog.
     def _post_valid_options(self, post_type=None):
         # These options are always valid
-        valid = ['type', 'state', 'tags', 'tweet', 'date', 'format', 'slug']
+        valid = ['type', 'state', 'tags', 'tweet', 'date', 'format', 'slug', 'source_url']
 
         # Other options are valid on a per-post-type basis
         if post_type == 'text':


### PR DESCRIPTION
Add support for source_url in posts as described by the HTTP API.
closes: #145 

Note:  `source_url ` overrides  `external_url` as source for the post (not the audio). This behavior is expected.