### PR TITLE
Add PyYAML warning in interactive_console.py

### DIFF
--- a/interactive_console.py
+++ b/interactive_console.py
@@ -5,10 +5,15 @@ standard_library.install_aliases()
 from builtins import input
 
 import pytumblr
-import yaml
 import os
 import code
 from requests_oauthlib import OAuth1Session
+try:
+    import yaml
+except ImportError:
+    print('You need PyYAML to run interactive console\npip install pyyaml')
+    import sys
+    sys.exit(-1)
 
 
 def new_oauth(yaml_path):


### PR DESCRIPTION
If can't import PyYAML => print warning and `sys.exit(-1)`